### PR TITLE
Fix location of anonymizeIp code.

### DIFF
--- a/simple-analytics.php
+++ b/simple-analytics.php
@@ -136,14 +136,14 @@ class Theme_Blvd_Simple_Analytics {
 	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
 	ga('create', '<?php echo esc_attr( $settings['google_id'] ); ?>', 'auto');
-	ga('send', 'pageview');
 	<?php
 	if ( ! empty( $settings['anonymize'] ) ) {
 
-		echo "ga('set', 'anonymizeIp', true);\n";
+		echo "ga('set', 'anonymizeIp', true);";
 
 	}
 	?>
+	ga('send', 'pageview');
 
 </script>
 <?php


### PR DESCRIPTION
The line to enable the anonymizeIp feature should go before the "send pageview" call.

In the PR I furthermore removed the `\n` linebreak since that will actually insert an additional unnecessary linebreak (there's already one from opening and closing the PHP tags). The latter is of course only minor.